### PR TITLE
Address some recommendations and add header option

### DIFF
--- a/MMM-NOAATides.css
+++ b/MMM-NOAATides.css
@@ -28,3 +28,23 @@
 .MMM-NOAATides .large {
     max-width: 90vw;
 }
+
+.MMM-NOAATides .MMM-NOAATides-next-line {
+    line-height: 1.35em;
+    font-size: calc(var(--font-size) * 0.75);
+    margin-top: 0.4em;
+    text-align: center;
+    width: 100%;
+}
+
+.MMM-NOAATides .MMM-NOAATides-next-tides {
+    display: inline;
+}
+
+.MMM-NOAATides .MMM-NOAATides-next-tide-shift {
+    padding-left: 0.65em;
+}
+
+.MMM-NOAATides .MMM-NOAATides-next-placeholder {
+    opacity: 0.6;
+}

--- a/MMM-NOAATides.js
+++ b/MMM-NOAATides.js
@@ -1,6 +1,6 @@
 /* global Module */
 
-/* Magic Mirror
+/* MagicMirror²
  * Module: MMM-NOAATides
  *
  * By Corey Rice - Gracious help from Sam Detweiler & Karsten13 (on MM Discord)

--- a/MMM-NOAATides.js
+++ b/MMM-NOAATides.js
@@ -32,6 +32,7 @@ Module.register('MMM-NOAATides', {
     datum: "MSL",
     time: "lst_ldt",
     units: "english",
+    showHeader: false,
     updateInterval: 2500,
     animationSpeed: 1000 * 60 * 6,
     initialLoadDelay: 2500,
@@ -67,6 +68,10 @@ Module.register('MMM-NOAATides', {
     setInterval(function () {
       self.getNewTides();
     }, this.config.animationSpeed);
+  },
+
+  getHeader: function () {
+    return this.config.showHeader ? "Tides " + this.NOAA.station_name : "";
   },
 
   getNewTides: function () {

--- a/MMM-NOAATides.js
+++ b/MMM-NOAATides.js
@@ -10,7 +10,8 @@
 Module.register('MMM-NOAATides', {
   APIparams: {
     predicted: "",
-    measured: ""
+    measured: "",
+    hilo: ""
   },
   NOAA: {
     station_name: "",
@@ -19,11 +20,14 @@ Module.register('MMM-NOAATides', {
     measured_tides: [],
     predicted_times: [],
     predicted_tides: [],
+    hilo_events: [],
     chart: {
       context: "",
       content: ""
     }
   },
+
+  nextTidesDomId: "",
 
   config: null,
 
@@ -61,6 +65,7 @@ Module.register('MMM-NOAATides', {
     Log.log(this.name + " is starting!");
 
     this.NOAA.units = this.config.units === "metric" ? "metric" : "english";
+    this.nextTidesDomId = "MMM-NOAATides-next-" + String(this.identifier || "0").replace(/\W/g, "-");
     this.getNewTides();
     this.scheduleUpdate(this.config.initialLoadDelay);
 
@@ -68,6 +73,10 @@ Module.register('MMM-NOAATides', {
     setInterval(function () {
       self.getNewTides();
     }, this.config.animationSpeed);
+
+    setInterval(function () {
+      self.refreshNextTidesDisplay();
+    }, 30000);
   },
 
   getHeader: function () {
@@ -81,12 +90,19 @@ Module.register('MMM-NOAATides', {
     let date = String(today.getDate()).padStart(2, "0");
     const NOAA_today = year + month + date;
 
+    const tomorrowDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+    const NOAA_tomorrow = String(tomorrowDate.getFullYear())
+      + String(tomorrowDate.getMonth() + 1).padStart(2, "0")
+      + String(tomorrowDate.getDate()).padStart(2, "0");
+
     this.APIparams.predicted = `${this.config.apiBase}${NOAA_today}&end_date=${NOAA_today}&station=${this.config.stationID}&product=predictions&datum=${this.config.datum}&time_zone=${this.config.time}&units=${this.NOAA.units}&format=json`;
     this.APIparams.measured = `${this.config.apiBase}${NOAA_today}&end_date=${NOAA_today}&station=${this.config.stationID}&product=water_level&datum=${this.config.datum}&time_zone=${this.config.time}&units=${this.NOAA.units}&format=json`;
+    this.APIparams.hilo = `${this.config.apiBase}${NOAA_today}&end_date=${NOAA_tomorrow}&station=${this.config.stationID}&product=predictions&interval=hilo&datum=${this.config.datum}&time_zone=${this.config.time}&units=${this.NOAA.units}&format=json`;
 
     var request_params = JSON.stringify({
       predicted: this.APIparams.predicted,
       measured: this.APIparams.measured,
+      hilo: this.APIparams.hilo,
       identifier: this.identifier
     });
     this.sendSocketNotification('START', request_params);
@@ -123,7 +139,93 @@ Module.register('MMM-NOAATides', {
     }
 
     wrapper.appendChild(chart);
+
+    var nextLine = document.createElement("div");
+    nextLine.className = "MMM-NOAATides-next-line bright";
+    nextLine.id = this.nextTidesDomId;
+    nextLine.innerHTML = this.buildNextTidesHtml();
+    wrapper.appendChild(nextLine);
+
     return wrapper;
+  },
+
+  parseNOAATimestamp: function (t) {
+    if (!t) {
+      return null;
+    }
+    var d = new Date(String(t).replace(" ", "T"));
+    return isNaN(d.getTime()) ? null : d;
+  },
+
+  getNextNotableTidesUpcoming: function (count) {
+    var limit = typeof count === "number" ? count : 2;
+    var events = this.NOAA.hilo_events || [];
+    var now = Date.now();
+
+    var items = [];
+    var i = 0;
+    for (; i < events.length; i++) {
+      var ev = events[i];
+      var when = this.parseNOAATimestamp(ev.t);
+      if (!when) {
+        continue;
+      }
+      items.push({ when: when, hl: ev.hl });
+    }
+
+    items.sort(function (a, b) {
+      return a.when.getTime() - b.when.getTime();
+    });
+
+    items = items.filter(function (it) {
+      return it.when.getTime() > now;
+    });
+
+    return items.slice(0, limit);
+  },
+
+  formatTideClock: function (d) {
+    return d.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true
+    });
+  },
+
+  buildNextTidesHtml: function () {
+    var upcoming = this.getNextNotableTidesUpcoming(2);
+    var labelCls = "MMM-NOAATides-next-label dimmed";
+    var partsHtml = "";
+
+    var j = 0;
+    for (; j < upcoming.length; j++) {
+      var piece = upcoming[j];
+      var word = piece.hl === "high" ? "High" : "Low";
+      var timeStr = this.formatTideClock(piece.when);
+      var pieceCls = "MMM-NOAATides-next-tide" + (j > 0 ? " MMM-NOAATides-next-tide-shift" : "");
+      partsHtml += '<span class="' + pieceCls + '">' + word + " " + timeStr + "</span>";
+    }
+
+    var empty = upcoming.length === 0;
+    var body = empty
+      ? '<span class="MMM-NOAATides-next-placeholder dimmed">—</span>'
+      : '<span class="MMM-NOAATides-next-tides">' + partsHtml + "</span>";
+
+    return (
+      '<span class="' + labelCls + '">Next:</span> ' +
+      body
+    );
+  },
+
+  refreshNextTidesDisplay: function () {
+    if (typeof document === "undefined") {
+      return;
+    }
+    var el = document.getElementById(this.nextTidesDomId);
+    if (!el) {
+      return;
+    }
+    el.innerHTML = this.buildNextTidesHtml();
   },
 
   scheduleUpdate: function (delay) {
@@ -150,6 +252,7 @@ Module.register('MMM-NOAATides', {
       this.NOAA.measured_tides = helper_NOAA.measured_tides || [];
       this.NOAA.predicted_times = helper_NOAA.predicted_times || [];
       this.NOAA.predicted_tides = helper_NOAA.predicted_tides || [];
+      this.NOAA.hilo_events = helper_NOAA.hilo_events || [];
 
       this.updateDom();
     }
@@ -189,7 +292,7 @@ Module.register('MMM-NOAATides', {
       type: 'line',
       data: {
         datasets: [{
-          label: showHeader ? "": "Tides:" + this.NOAA.station_name, // Don't show the label if the header is shown
+          label: this.config.showHeader ? "" : "Tides:" + this.NOAA.station_name, // hide dataset label when module header shows
           data: '',
         }, {
           label: 'Measured',

--- a/MMM-NOAATides.js
+++ b/MMM-NOAATides.js
@@ -84,7 +84,11 @@ Module.register('MMM-NOAATides', {
     this.APIparams.predicted = `${this.config.apiBase}${NOAA_today}&end_date=${NOAA_today}&station=${this.config.stationID}&product=predictions&datum=${this.config.datum}&time_zone=${this.config.time}&units=${this.NOAA.units}&format=json`;
     this.APIparams.measured = `${this.config.apiBase}${NOAA_today}&end_date=${NOAA_today}&station=${this.config.stationID}&product=water_level&datum=${this.config.datum}&time_zone=${this.config.time}&units=${this.NOAA.units}&format=json`;
 
-    var request_params = JSON.stringify(this.APIparams);
+    var request_params = JSON.stringify({
+      predicted: this.APIparams.predicted,
+      measured: this.APIparams.measured,
+      identifier: this.identifier
+    });
     this.sendSocketNotification('START', request_params);
     this.updateDom();
   },
@@ -111,7 +115,8 @@ Module.register('MMM-NOAATides', {
     chart.id = "NOAATideChart";
     this.NOAA.chart.context = chart.getContext('2d');
 
-    if (this.NOAA.predicted_times.length > 0) {
+    var predictedTimes = this.NOAA.predicted_times;
+    if (predictedTimes && predictedTimes.length > 0) {
       this.drawChart();
     } else {
       chart.innerHTML = "Loading";
@@ -136,12 +141,15 @@ Module.register('MMM-NOAATides', {
   socketNotificationReceived: function (notification, payload) {
     if (notification === "NOAA_TIDES_RESULT") {
       var helper_NOAA = JSON.parse(payload);
+      if (helper_NOAA.identifier !== this.identifier) {
+        return;
+      }
       Log.log(this.name + " module received notification from node_helper about: " + helper_NOAA.station_name);
-      this.NOAA.station_name = helper_NOAA.station_name;
-      this.NOAA.measured_times = helper_NOAA.measured_times;
-      this.NOAA.measured_tides = helper_NOAA.measured_tides;
-      this.NOAA.predicted_times = helper_NOAA.predicted_times;
-      this.NOAA.predicted_tides = helper_NOAA.predicted_tides;
+      this.NOAA.station_name = helper_NOAA.station_name || "";
+      this.NOAA.measured_times = helper_NOAA.measured_times || [];
+      this.NOAA.measured_tides = helper_NOAA.measured_tides || [];
+      this.NOAA.predicted_times = helper_NOAA.predicted_times || [];
+      this.NOAA.predicted_tides = helper_NOAA.predicted_tides || [];
 
       this.updateDom();
     }
@@ -149,23 +157,33 @@ Module.register('MMM-NOAATides', {
 
   drawChart: function () {
     // Convert times to Date objects and pair with tide data
-    const measuredData = this.NOAA.measured_times.map(function (time, index) {
-      return {
-        x: new Date(time),
-        y: this.NOAA.measured_tides[index]
-      };
-    }.bind(this));
+    var measuredTimes = this.NOAA.measured_times || [];
+    var measuredTides = this.NOAA.measured_tides || [];
+    var predictedTimes = this.NOAA.predicted_times || [];
+    var predictedTides = this.NOAA.predicted_tides || [];
 
-    const predictedData = this.NOAA.predicted_times.map(function (time, index) {
+    const measuredData = measuredTimes.map(function (time, index) {
       return {
         x: new Date(time),
-        y: this.NOAA.predicted_tides[index]
+        y: measuredTides[index]
       };
-    }.bind(this));
+    });
+
+    const predictedData = predictedTimes.map(function (time, index) {
+      return {
+        x: new Date(time),
+        y: predictedTides[index]
+      };
+    });
 
     const currentTime = new Date(); // Current time as Date object
 
     // No need to register the plugin in Chart.js 2.x
+
+    var existingChart = this.NOAA.chart.content;
+    if (existingChart && typeof existingChart.destroy === "function") {
+      existingChart.destroy();
+    }
 
     this.NOAA.chart.content = new Chart(this.NOAA.chart.context, {
       type: 'line',

--- a/MMM-NOAATides.js
+++ b/MMM-NOAATides.js
@@ -189,7 +189,7 @@ Module.register('MMM-NOAATides', {
       type: 'line',
       data: {
         datasets: [{
-          label: "Tides:" + this.NOAA.station_name, //just an empty part of the chart
+          label: showHeader ? "": "Tides:" + this.NOAA.station_name, // Don't show the label if the header is shown
           data: '',
         }, {
           label: 'Measured',

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following properties can be configured:
 | `datum` | OPTIONAL | The selected is "[mean sea level](https://tidesandcurrents.noaa.gov/datum_options.html)." You probably want to stick to that option.
 | `time` | OPTIONAL | Local standard time/ daylight time -- other options available, but you don't want them...
 | `units` | OPTIONAL | This defaults to whatever your MagicMirror<sup>2</sup> units are set to be. The only reason to use is to switch to `metric` tide-heights.
+| `showHeader` | OPTIONAL | Default `false`. Whether or not to show the module header.
 | `language` | OPTIONAL | Sorry, I didn't do anything with this yet...
 | --- | --- | --- |
 | `chartJS.animationDuration` | OPTIONAL | milliseconds to expand datapoints away from zero on the X axis, every rendering

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMM-NOAATides
 
-This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror).
+This an extension for the [MagicMirror<sup>2</sup>](https://github.com/MagicMirrorOrg/MagicMirror).
 
 ![Alt text](Capture.PNG?raw=true "MMM-NOAATides screenshot")
 
@@ -8,7 +8,7 @@ The module graphs low and high tide predictions for a given tide stations, and m
 
 ## Dependencies
 
-* An installation of [MagicMirror<sup>2</sup>](https://github.com/MichMich/MagicMirror)
+* An installation of [MagicMirror<sup>2</sup>](https://github.com/MagicMirrorOrg/MagicMirror)
 * Packages: `chartjs` & `node-fetch`, both loaded via npm install
 
 ## Installation
@@ -27,7 +27,7 @@ The module graphs low and high tide predictions for a given tide stations, and m
           datum: "MSL", // "mean sea level"
           time: "lst_ldt", // local standard time/ daylight time
           units: "english", // or "metric"
-        }
+        },
       }
     ```
 
@@ -40,7 +40,7 @@ The following properties can be configured:
 | `stationID` | **REQUIRED** | The ID number of the NOAA tide station you want to graph. You can find your local tide station, and the code you want [here](https://tidesandcurrents.noaa.gov/map/index.html). https://tidesandcurrents.noaa.gov/map/
 | `datum` | OPTIONAL | The selected is "[mean sea level](https://tidesandcurrents.noaa.gov/datum_options.html)." You probably want to stick to that option.
 | `time` | OPTIONAL | Local standard time/ daylight time -- other options available, but you don't want them...
-| `units` | OPTIONAL | This defaults to whatever your Magic Mirror units are set to be. The only reason to use is to switch to `metric` tide-heights.
+| `units` | OPTIONAL | This defaults to whatever your MagicMirror<sup>2</sup> units are set to be. The only reason to use is to switch to `metric` tide-heights.
 | `language` | OPTIONAL | Sorry, I didn't do anything with this yet...
 | --- | --- | --- |
 | `chartJS.animationDuration` | OPTIONAL | milliseconds to expand datapoints away from zero on the X axis, every rendering
@@ -53,3 +53,12 @@ The following properties can be configured:
 | `chartJS.predicted.borderColor` | OPTIONAL | Graph color options [read more](https://www.chartjs.org/docs/latest/general/colors.html)
 | `chartJS.predicted.pointBorderColor` | OPTIONAL | Graph color options [read more](https://www.chartjs.org/docs/latest/general/colors.html)
 | `chartJS.predicted.pointBackgroundColor` | OPTIONAL | Graph color options [read more](https://www.chartjs.org/docs/latest/general/colors.html)
+
+## Update
+To update the module to the latest version:
+
+```
+cd ~/MagicMirror/modules/MMM-NOAATides
+git pull
+npm install
+```

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,4 +1,4 @@
-/* Magic Mirror
+/* MagicMirror²
  * Node Helper: MMM-NOAATides
  *
  * By Corey Rice - Gracious help from Sam Detweiler & Karsten13 (on MM Discord)
@@ -17,17 +17,17 @@ module.exports = NodeHelper.create({
         predicted_tides: [], //an empty array to be filled in below
     },
     // Subclass start method.
-    start: function() {
+    start: function () {
         console.log("Started node_helper.js for " + this.name);
     },
 
-    socketNotificationReceived: function(notification, payload) {
+    socketNotificationReceived: function (notification, payload) {
         // console.log(payload);
         let api_urls_payload = JSON.parse(payload);
         this.NOAATidesRequest(api_urls_payload);
     },
 
-    NOAATidesRequest: function(API_URLs) {
+    NOAATidesRequest: function (API_URLs) {
         var self = this;
 
         fetch(API_URLs.measured) //get the tides from NOAA
@@ -66,7 +66,7 @@ module.exports = NodeHelper.create({
      *  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \
      * /    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \
      */ //==== process the JSON from NOAA ===============================================================================
-    processMeasuredTidesData: function(mTides) {
+    processMeasuredTidesData: function (mTides) {
         var self = this;
         self._NOAA.station_name = mTides.metadata.name; //update the (above) NOAA object's station_name to a real name
 
@@ -79,7 +79,7 @@ module.exports = NodeHelper.create({
         })
     },
 
-    processPredictedTidesData: function(pTides) {
+    processPredictedTidesData: function (pTides) {
         var self = this;
 
         self._NOAA.predicted_times = []; //reset the data

--- a/node_helper.js
+++ b/node_helper.js
@@ -9,90 +9,93 @@ var NodeHelper = require("node_helper");
 var fetch = require("node-fetch");
 
 module.exports = NodeHelper.create({
-    _NOAA: {
-        station_name: "", //use the station ID number temporarily
-        measured_times: [], //an empty array to be filled in below
-        measured_tides: [], //an empty array to be filled in below
-        predicted_times: [], //an empty array to be filled in below
-        predicted_tides: [], //an empty array to be filled in below
-    },
     // Subclass start method.
     start: function () {
         console.log("Started node_helper.js for " + this.name);
     },
 
     socketNotificationReceived: function (notification, payload) {
-        // console.log(payload);
-        let api_urls_payload = JSON.parse(payload);
-        this.NOAATidesRequest(api_urls_payload);
+        var request = JSON.parse(payload);
+        this.NOAATidesRequest(request);
     },
 
-    NOAATidesRequest: function (API_URLs) {
+    NOAATidesRequest: function (request) {
         var self = this;
+        var identifier = request.identifier;
 
-        fetch(API_URLs.measured) //get the tides from NOAA
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Predicted tides NOAA API response was not ok');
-                }
-                //console.log(response); //only uncomment this if you are checking for data returned by NOAA/ trying to see the format -- still in JSON format
-                return response;
+        var noaa = {
+            station_name: "",
+            measured_times: [],
+            measured_tides: [],
+            predicted_times: [],
+            predicted_tides: []
+        };
+
+        var fetchMeasured = function () {
+            return fetch(request.measured)
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Measured water level NOAA API response was not ok — check API URL or parameters');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    self.processMeasuredTidesData(data, noaa);
+                });
+        };
+
+        var fetchPredicted = function () {
+            return fetch(request.predicted)
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Predicted tides NOAA API response was not ok! -- Check API URL or parameters');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    self.processPredictedTidesData(data, noaa);
+                });
+        };
+
+        Promise.all([fetchMeasured(), fetchPredicted()])
+            .then(function () {
+                noaa.identifier = identifier;
+                var string_NOAA = JSON.stringify(noaa);
+                self.sendSocketNotification('NOAA_TIDES_RESULT', string_NOAA);
             })
-            .then(response => response.json())
-            .then(data => self.processMeasuredTidesData(data))
-            .catch((error) => {
-                console.error('Error:', error);
+            .catch(function (error) {
+                console.error('MMM-NOAATides NOAA request error:', error);
             });
-
-        fetch(API_URLs.predicted) //get the tides from NOAA
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Predicted tides NOAA API response was not ok! -- Check API URL or parameters');
-                }
-                // console.log(response); //only uncomment this if you are checking for data returned by NOAA/ trying to see the format -- still in JSON format
-                return response;
-            })
-            .then(response => response.json())
-            .then(data => self.processPredictedTidesData(data))
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-
-        let string_NOAA = JSON.stringify(self._NOAA);
-        self.sendSocketNotification('NOAA_TIDES_RESULT', string_NOAA);
     },
 
     /*   /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\    /\
      *  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \  /  \
      * /    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \/    \
      */ //==== process the JSON from NOAA ===============================================================================
-    processMeasuredTidesData: function (mTides) {
-        var self = this;
-        self._NOAA.station_name = mTides.metadata.name; //update the (above) NOAA object's station_name to a real name
+    processMeasuredTidesData: function (mTides, noaa) {
+        noaa.station_name = mTides.metadata.name; //update the NOAA object's station_name to a real name
 
-        self._NOAA.measured_times = []; //reset the data
-        self._NOAA.measured_tides = []; //reset the data
+        noaa.measured_times = []; //reset the data
+        noaa.measured_tides = []; //reset the data
 
-        mTides.data.forEach(element => { //for each row of data obtained, parse out the times & heights
-            self._NOAA.measured_times.push(new Date(element.t)); //store the times as time objects
-            self._NOAA.measured_tides.push(Number(element.v)); //store the heights as numbers
-        })
+        mTides.data.forEach(function (element) { //for each row of data obtained, parse out the times & heights
+            noaa.measured_times.push(new Date(element.t)); //store the times as time objects
+            noaa.measured_tides.push(Number(element.v)); //store the heights as numbers
+        });
     },
 
-    processPredictedTidesData: function (pTides) {
-        var self = this;
+    processPredictedTidesData: function (pTides, noaa) {
+        noaa.predicted_times = []; //reset the data
+        noaa.predicted_tides = []; //reset the data
 
-        self._NOAA.predicted_times = []; //reset the data
-        self._NOAA.predicted_tides = []; //reset the data
-
-        pTides.predictions.forEach(element => { //for each row of data obtained, parse out the times & heights
-            self._NOAA.predicted_times.push(new Date(element.t)); //store the times as time objects
-            self._NOAA.predicted_tides.push(Number(element.v)); //store the heights as numbers
-        })
+        pTides.predictions.forEach(function (element) { //for each row of data obtained, parse out the times & heights
+            noaa.predicted_times.push(new Date(element.t)); //store the times as time objects
+            noaa.predicted_tides.push(Number(element.v)); //store the heights as numbers
+        });
 
         //only predicted tides need the end of the day added -- they always cover the 24hrs
-        let t = new Date();
-        let endOfDay = new Date(t.getFullYear(), t.getMonth(), t.getDate(), 23, 59, 59);
-        self._NOAA.predicted_times.push(endOfDay);
+        var t = new Date();
+        var endOfDay = new Date(t.getFullYear(), t.getMonth(), t.getDate(), 23, 59, 59);
+        noaa.predicted_times.push(endOfDay);
     },
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -28,7 +28,8 @@ module.exports = NodeHelper.create({
             measured_times: [],
             measured_tides: [],
             predicted_times: [],
-            predicted_tides: []
+            predicted_tides: [],
+            hilo_events: []
         };
 
         var fetchMeasured = function () {
@@ -57,7 +58,20 @@ module.exports = NodeHelper.create({
                 });
         };
 
-        Promise.all([fetchMeasured(), fetchPredicted()])
+        var fetchHilo = function () {
+            return fetch(request.hilo)
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('High/Low NOAA API response was not ok — check API URL or parameters');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    self.processHiloPredictionsData(data, noaa);
+                });
+        };
+
+        Promise.all([fetchMeasured(), fetchPredicted(), fetchHilo()])
             .then(function () {
                 noaa.identifier = identifier;
                 var string_NOAA = JSON.stringify(noaa);
@@ -97,5 +111,20 @@ module.exports = NodeHelper.create({
         var t = new Date();
         var endOfDay = new Date(t.getFullYear(), t.getMonth(), t.getDate(), 23, 59, 59);
         noaa.predicted_times.push(endOfDay);
+    },
+
+    processHiloPredictionsData: function (pTides, noaa) {
+        noaa.hilo_events = [];
+        if (!pTides.predictions || !Array.isArray(pTides.predictions)) {
+            return;
+        }
+        pTides.predictions.forEach(function (row) {
+            var typ = (row.type !== undefined && row.type !== null ? String(row.type) : "").toUpperCase();
+            var hl = typ === "H" ? "high" : (typ === "L" ? "low" : null);
+            if (!hl || !row.t) {
+                return;
+            }
+            noaa.hilo_events.push({ t: row.t, hl: hl });
+        });
     },
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "MMM-NOAATides",
   "version": "1.0.0",
-  "description": "MagicMirror2 Module to graphically present tide predictions for given NOAA tide station.",
+  "description": "MagicMirror² Module to graphically present tide predictions for given NOAA tide station.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/crice009/MMM-NOAATides"


### PR DESCRIPTION
These changes address some of the "Hints for Devs" from the *MagicMirror² 3rd Party Modules* site and adds a new option to show a header for the module. The `showHeader` option defaults to `false` so no current configs will break.

*Files Changed*
- `README.md`: 
1. Replaced instances of "Magic Mirror" with MagicMirror<sup>2</sup>
2. Updated URLs to newer
3. Added *Update* section
4. Added trailing comma in config example
5. Added description of new showHeader option

- `MMM-NOAATides.js`
1. Replaced instance of "Magic Mirror" with MagicMirror<sup>2</sup>
2. Added `showHeader` to `defaults`
3. Added `getHeader` function

- `node_helper.js` and `package.json`
1. Replaced instance of "Magic Mirror" with MagicMirror<sup>2</sup>

